### PR TITLE
Add example of math equations rendering using MathJax to the markdown…

### DIFF
--- a/html.js
+++ b/html.js
@@ -35,6 +35,9 @@ module.exports = React.createClass({
           <TypographyStyle typography={typography} />
           <GoogleFont typography={typography} />
           {css}
+          <script type="text/javascript" async
+            src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML">
+          </script>
         </head>
         <body>
           <div id="react-mount" dangerouslySetInnerHTML={{ __html: this.props.body }} />

--- a/loaders/markdown-loader/index.js
+++ b/loaders/markdown-loader/index.js
@@ -30,6 +30,7 @@ var md = markdownIt({
   .use(require('markdown-it-deflist'))
   .use(require('markdown-it-abbr'))
   .use(require('markdown-it-attrs'))
+  .use(require('markdown-it-mathjax'))
 
 module.exports = function (content) {
   this.cacheable()

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "markdown-it-attrs": "^0.6.3",
     "markdown-it-deflist": "^2.0.1",
     "markdown-it-footnote": "^3.0.1",
+    "markdown-it-mathjax": "^2.0.0",
     "markdown-it-sub": "^1.0.0",
     "object-assign": "^4.1.1",
     "react-headroom": "^2.1.4",

--- a/pages/markdown.md
+++ b/pages/markdown.md
@@ -86,3 +86,56 @@ for i in range(10):
     time.sleep(0.5)
     print i
 ```
+
+
+## Mathematical Equations
+
+Inline math with special characters: $|\psi\rangle$, $\Omega'$, $\gamma^\*$.  Bayes formula is $p(x|y) = \frac{p(y|x)p(x)}{p(y)}$.
+
+Bigger equations:
+
+$$
+\begin{align}
+E(\mathbf{v}, \mathbf{h}) = -\sum_{i,j}w_{ij}v_i h_j - \sum_i b_i v_i - \sum_j c_j h_j
+\end{align}
+$$
+
+In multiline is:
+
+$$
+\begin{align}
+                p(v_i=1|\mathbf{h}) & = \sigma\left(\sum_j w_{ij}h_j + b_i\right) \\\\
+                p(h_j=1|\mathbf{v}) & = \sigma\left(\sum_i w_{ij}v_i + c_j\right)
+\end{align}
+$$
+
+
+And without numbering:
+$$
+  \begin{align\*}
+    |\psi_1\rangle &= a|0\rangle + b|1\rangle \\\\
+    |\psi_2\rangle &= c|0\rangle + d|1\rangle
+  \end{align\*}
+$$
+
+Miltiline alignment:
+$$
+\begin{equation} 
+\begin{split}
+A & = \frac{\pi r^2}{2} \\\\
+  & = \frac{1}{2} \pi r^2 \\\\
+  & = \frac{A}{B_{C}} \psi r^{\theta} \\\\
+\end{split}
+\end{equation}
+$$
+
+And matrices too:
+$$
+A_{m,n} = 
+ \begin{pmatrix}
+  a_{1,1} & a_{1,2} & \cdots & a_{1,n} \\\\
+  a_{2,1} & a_{2,2} & \cdots & a_{2,n} \\\\
+  \vdots  & \vdots  & \ddots & \vdots  \\\\
+  a_{m,1} & a_{m,2} & \cdots & a_{m,n} 
+ \end{pmatrix}
+$$

--- a/wrappers/md.js
+++ b/wrappers/md.js
@@ -9,6 +9,22 @@ module.exports = React.createClass({
       router: React.PropTypes.object,
     }
   },
+/*
+  getInitialState () {
+    MathJax.Hub.Config({
+      TeX: {
+        equationNumbers: {
+          autoNumber: "AMS"
+        }
+      },
+      tex2jax: {
+        inlineMath: [ ['$','$'], ['\(', '\)'] ],
+        displayMath: [ ['$$','$$'] ],
+        processEscapes: true,
+      }
+    });
+  },
+*/
   render () {
     const post = this.props.route.page.data
     return (
@@ -21,4 +37,34 @@ module.exports = React.createClass({
       </div>
     )
   },
+  componentDidMount() {
+      MathJax.Hub.Config({
+        TeX: {
+          equationNumbers: {
+            autoNumber: "AMS"
+          }
+        },
+        tex2jax: {
+          inlineMath: [ ['$','$'], ['\(', '\)'] ],
+          displayMath: [ ['$$','$$'] ],
+          processEscapes: true,
+        }
+      });
+      MathJax.Hub.Queue(['Typeset', MathJax.Hub])
+  },
+  componentDidUpdate() {
+      MathJax.Hub.Config({
+        TeX: {
+          equationNumbers: {
+            autoNumber: "AMS"
+          }
+        },
+        tex2jax: {
+          inlineMath: [ ['$','$'], ['\(', '\)'] ],
+          displayMath: [ ['$$','$$'] ],
+          processEscapes: true,
+        }
+      });
+      MathJax.Hub.Queue(['Typeset', MathJax.Hub])
+  }
 })


### PR DESCRIPTION
@KyleAMathews please review this code.  I'd like to add some MathJax rendering examples, however, I'm not sure where is the best place to put this bit of code:

```javascript
    MathJax.Hub.Config({
      TeX: {
        equationNumbers: {
          autoNumber: "AMS"
        }
      },
      tex2jax: {
        inlineMath: [ ['$','$'], ['\(', '\)'] ],
        displayMath: [ ['$$','$$'] ],
        processEscapes: true,
      }
    });
```

The way it is right now in `md.js` means the equation numbers do not always begin from `1` when you return to the page after hitting back.  Also, putting this bit code in a function `getInitialState()` gives a blank page.